### PR TITLE
Recreate interface with old color scheme

### DIFF
--- a/KAOLO_STORE/src/app/login/login.html
+++ b/KAOLO_STORE/src/app/login/login.html
@@ -81,6 +81,21 @@
   </div>
   <p class="mt-2 text-sm text-gray-500" id="phone-description">Veuillez inclure l'indicatif de votre pays (ex: +237).</p>
 </div>
+
+<!-- Catégorie -->
+<div class="max-w-md mx-auto mt-4">
+  <label for="categorie" class="block text-sm font-medium text-gray-700">Catégorie</label>
+  <select id="categorie" name="categorie"
+          class="mt-1 w-full rounded-xl border border-gray-300 bg-white px-3 py-3 text-gray-900 shadow-sm focus:border-orange-500 focus:ring-2 focus:ring-orange-500/30 outline-none">
+    <option value="" selected disabled>Choisir une catégorie</option>
+    <option value="electronique">Électronique</option>
+    <option value="mode">Mode</option>
+    <option value="maison">Maison & Cuisine</option>
+    <option value="beaute">Beauté</option>
+    <option value="jouets">Jouets</option>
+    <option value="sport">Sport</option>
+  </select>
+</div>
 <label class="flex items-start gap-3 text-sm text-gray-600">
     <input type="checkbox" class="mt-1 h-4 w-4 rounded border-gray-300 accent-orange-500" />
     <span class="leading-snug">J'accepte les <a href="#" class="font-medium text-pink-600 hover:underline">Conditions d'utilisation</a> et la <a href="#" class="font-medium text-pink-600 hover:underline">Politique de confidentialité</a>.</span>

--- a/KAOLO_STORE/src/app/login/login.html
+++ b/KAOLO_STORE/src/app/login/login.html
@@ -1,4 +1,4 @@
-<body class="min-h-screen bg-gradient-to-br from-fuchsia-600 via-pink-500 to-orange-400">
+<body class="min-h-screen bg-gray-100">
   <div class="min-h-screen flex items-center justify-center p-6">
     <div class="relative w-full max-w-md">
       <div class="rounded-3xl bg-white/90 shadow-xl backdrop-blur-sm p-8 pt-16">
@@ -23,7 +23,7 @@
                 </svg>
               </span>
               <input type="text" placeholder="Nom complet"
-                     class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-pink-500 focus:ring-2 focus:ring-pink-500/30 outline-none" />
+                     class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-orange-500 focus:ring-2 focus:ring-orange-500/30 outline-none" />
             </div>
           </div>
 
@@ -37,7 +37,7 @@
                 </svg>
               </span>
               <input type="email" placeholder="E‑mail"
-                     class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-pink-500 focus:ring-2 focus:ring-pink-500/30 outline-none" />
+                     class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-orange-500 focus:ring-2 focus:ring-orange-500/30 outline-none" />
             </div>
           </div>
             <!-- Mot de passe -->
@@ -50,7 +50,7 @@
                   </svg>
                 </span>
                 <input type="password" placeholder="Mot de passe"
-                       class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-pink-500 focus:ring-2 focus:ring-pink-500/30 outline-none" />
+                       class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-orange-500 focus:ring-2 focus:ring-orange-500/30 outline-none" />
                 </div>
             </div>
             <div>
@@ -63,7 +63,7 @@
                   </svg>
                 </span>
                 <input type="password" placeholder="Confirmer mot de passe"
-                       class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-pink-500 focus:ring-2 focus:ring-pink-500/30 outline-none" />
+                       class="w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-orange-500 focus:ring-2 focus:ring-orange-500/30 outline-none" />
                 </div>
             </div>
             </div>
@@ -76,7 +76,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
       </svg>
     </div>
-    <input type="tel" name="phone-number" id="phone-number" class="block w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-pink-500 focus:ring-2 focus:ring-pink-500/30 outline-none" placeholder="Veuillez entrer votre numero de telephone" aria-describedby="phone-description" />
+    <input type="tel" name="phone-number" id="phone-number" class="block w-full rounded-xl border border-gray-300 bg-white px-3 py-3 pl-10 text-gray-900 placeholder-gray-400 shadow-sm focus:border-orange-500 focus:ring-2 focus:ring-orange-500/30 outline-none" placeholder="Veuillez entrer votre numero de telephone" aria-describedby="phone-description" />
     
   </div>
   <p class="mt-2 text-sm text-gray-500" id="phone-description">Veuillez inclure l'indicatif de votre pays (ex: +237).</p>
@@ -85,7 +85,7 @@
     <input type="checkbox" class="mt-1 h-4 w-4 rounded border-gray-300 accent-orange-500" />
     <span class="leading-snug">J'accepte les <a href="#" class="font-medium text-pink-600 hover:underline">Conditions d'utilisation</a> et la <a href="#" class="font-medium text-pink-600 hover:underline">Politique de confidentialité</a>.</span>
 </label>
-            <button type="submit" class="w-full bg-gradient-to-r from-pink-500 to-orange-400 hover:from-pink-600 hover:to-orange-500 text-white font-semibold py-3 rounded-xl shadow-lg transition-colors duration-300">Créer mon compte</button>
+            <button type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-semibold py-3 rounded-xl shadow-lg transition-colors duration-300">Créer mon compte</button>
             </form>
             <p class="mt-6 text-center text-sm text-gray-600">Vous avez déjà un compte ? <a routerLink="/signin" class="font-medium text-pink-600 hover:underline">Connectez-vous</a></p>
         </div>


### PR DESCRIPTION
Apply old interface colors to inputs and buttons, revert background, and add a category dropdown as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-f73f51fd-a5aa-4b77-b4e9-9b988b918b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f73f51fd-a5aa-4b77-b4e9-9b988b918b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

